### PR TITLE
Feat/user route/#9

### DIFF
--- a/src/main/java/com/earseo/route/common/exception/RouteError.java
+++ b/src/main/java/com/earseo/route/common/exception/RouteError.java
@@ -10,7 +10,9 @@ public enum RouteError implements ErrorCodeInterface {
     INVALID_PLACE_IDS("RUT001", "최소 1개 이상의 관광지 ID가 필요합니다.", HttpStatus.BAD_REQUEST),
     ROUTE_NOT_FOUND("RUT002", "존재하지 않는 경로입니다.", HttpStatus.NOT_FOUND),
     ROUTE_NOT_OWNER("RUT003", "해당 사용자의 경로가 아닙니다.", HttpStatus.FORBIDDEN),
-    ROUTE_NOT_IN_PROGRESS("RUT004", "진행 중이 아닌 경로는 완료할 수 없습니다.", HttpStatus.CONFLICT);
+    ROUTE_NOT_IN_PROGRESS("RUT004", "진행 중이 아닌 경로는 완료할 수 없습니다.", HttpStatus.CONFLICT),
+
+    ROUTE_ITEM_NOT_IN_PROGRESS("RUT005", "진행 중인 경로의 아이템만 방문 처리할 수 있습니다.", HttpStatus.CONFLICT);
 
     private final String status;
     private final String message;

--- a/src/main/java/com/earseo/route/controller/RouteInProgressController.java
+++ b/src/main/java/com/earseo/route/controller/RouteInProgressController.java
@@ -21,24 +21,39 @@ public class RouteInProgressController {
     private final RouteInProgressService routeInProgressService;
 
     @Operation(
-            summary = "[내 경로 진행 관리] 진행 중 경로 생성 및 조회",
-            description = """
-                    사용자가 선택한 관광지 ID 리스트(placeIds)와 X-USER-ID를 기반으로
-                    진행 중 경로를 생성/조회합니다.
-                    - 관광지 메타 정보는 sight-service에서 조회하고,
-                    - sight 사이에 story_spot을 삽입하는 경로 계산은 별도 도메인 서비스에서 처리합니다.
-                    """
+            summary = "[내 경로 진행 관리] 진행 중 경로 생성",
+            description = "placeIds 기반으로 진행 중 경로를 새로 생성합니다. (기존 IN_PROGRESS가 있으면 삭제 후 재생성)"
     )
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
-                    description = "진행 중 경로 조회 성공",
+                    description = "진행 중 경로 생성 성공",
                     content = @Content(schema = @Schema(implementation = InProgressRouteDetailResponse.class))
             )
     })
     @PostMapping("/in-progress")
     public ResponseEntity<BaseResponse<InProgressRouteDetailResponse>> createInProgressRoute(@RequestHeader("X-USER-ID") Long userId, @RequestBody CreateRouteRequest request) {
         return ResponseEntity.ok(BaseResponse.ok(routeInProgressService.createInProgressRoute(userId, request)));
+    }
+
+    @Operation(
+            summary = "[단일 로그인] 로그인 직후 진행 중 경로 복구 조회",
+            description = """
+                    로그인 완료 직후 호출하는 API입니다.
+                    - 진행 중(IN_PROGRESS) 경로가 있으면 상세를 반환
+                    - 없으면 data=null 반환 (에러 아님)
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = InProgressRouteDetailResponse.class))
+            )
+    })
+    @GetMapping("/in-progress")
+    public ResponseEntity<BaseResponse<InProgressRouteDetailResponse>> getInProgressRoute(@RequestHeader("X-USER-ID") Long userId) {
+        return ResponseEntity.ok(BaseResponse.ok(routeInProgressService.getInProgressRoute(userId)));
     }
 
     @Operation(

--- a/src/main/java/com/earseo/route/controller/RouteInProgressController.java
+++ b/src/main/java/com/earseo/route/controller/RouteInProgressController.java
@@ -2,6 +2,7 @@ package com.earseo.route.controller;
 
 import com.earseo.route.common.BaseResponse;
 import com.earseo.route.dto.request.CreateRouteRequest;
+import com.earseo.route.dto.request.UpdateRouteItemVisitedRequest;
 import com.earseo.route.dto.response.InProgressRouteDetailResponse;
 import com.earseo.route.service.RouteInProgressService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -54,6 +55,19 @@ public class RouteInProgressController {
     @GetMapping("/in-progress")
     public ResponseEntity<BaseResponse<InProgressRouteDetailResponse>> getInProgressRoute(@RequestHeader("X-USER-ID") Long userId) {
         return ResponseEntity.ok(BaseResponse.ok(routeInProgressService.getInProgressRoute(userId)));
+    }
+
+    @Operation(
+            summary = "[내 경로 진행 관리] 경로 아이템 방문(리스닝) 상태 저장",
+            description = "진행 중(IN_PROGRESS) 경로의 특정 아이템(routeItemId)의 visited 상태를 업데이트합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "방문 상태 저장 성공")
+    })
+    @PatchMapping("/in-progress/items/{routeItemId}/visited")
+    public ResponseEntity<BaseResponse<Void>> updateVisited(@RequestHeader("X-USER-ID") Long userId, @PathVariable Long routeItemId, @RequestBody UpdateRouteItemVisitedRequest request) {
+        routeInProgressService.updateRouteItemVisited(userId, routeItemId, request.visited());
+        return ResponseEntity.ok(BaseResponse.ok(null));
     }
 
     @Operation(

--- a/src/main/java/com/earseo/route/controller/RouteInProgressController.java
+++ b/src/main/java/com/earseo/route/controller/RouteInProgressController.java
@@ -4,6 +4,7 @@ import com.earseo.route.common.BaseResponse;
 import com.earseo.route.dto.request.CreateRouteRequest;
 import com.earseo.route.dto.request.UpdateRouteItemVisitedRequest;
 import com.earseo.route.dto.response.InProgressRouteDetailResponse;
+import com.earseo.route.dto.response.SuccessResponse;
 import com.earseo.route.service.RouteInProgressService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -62,12 +63,16 @@ public class RouteInProgressController {
             description = "진행 중(IN_PROGRESS) 경로의 특정 아이템(routeItemId)의 visited 상태를 업데이트합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "방문 상태 저장 성공")
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+            )
     })
     @PatchMapping("/in-progress/items/{routeItemId}/visited")
-    public ResponseEntity<BaseResponse<Void>> updateVisited(@RequestHeader("X-USER-ID") Long userId, @PathVariable Long routeItemId, @RequestBody UpdateRouteItemVisitedRequest request) {
+    public ResponseEntity<BaseResponse<SuccessResponse>> updateVisited(@RequestHeader("X-USER-ID") Long userId, @PathVariable Long routeItemId, @RequestBody UpdateRouteItemVisitedRequest request) {
         routeInProgressService.updateRouteItemVisited(userId, routeItemId, request.visited());
-        return ResponseEntity.ok(BaseResponse.ok(null));
+        return ResponseEntity.ok(BaseResponse.ok(SuccessResponse.ok()));
     }
 
     @Operation(
@@ -77,12 +82,13 @@ public class RouteInProgressController {
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
-                    description = "경로 종료 처리 성공"
+                    description = "성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))
             )
     })
     @PostMapping("/{routeId}/complete")
-    public ResponseEntity<BaseResponse<Void>> completeRoute(@RequestHeader("X-USER-ID") Long userId, @PathVariable("routeId") Long routeId) {
+    public ResponseEntity<BaseResponse<SuccessResponse>> completeRoute(@RequestHeader("X-USER-ID") Long userId, @PathVariable("routeId") Long routeId) {
         routeInProgressService.completeRoute(userId, routeId);
-        return ResponseEntity.ok(BaseResponse.ok(null));
+        return ResponseEntity.ok(BaseResponse.ok(SuccessResponse.ok()));
     }
 }

--- a/src/main/java/com/earseo/route/dto/request/UpdateRouteItemVisitedRequest.java
+++ b/src/main/java/com/earseo/route/dto/request/UpdateRouteItemVisitedRequest.java
@@ -1,0 +1,11 @@
+package com.earseo.route.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.codehaus.commons.nullanalysis.NotNull;
+
+@Schema(description = "RouteItem 방문(리스닝) 상태 변경 요청")
+public record UpdateRouteItemVisitedRequest(
+        @NotNull
+        @Schema(description = "방문(리스닝) 완료 여부", example = "true")
+        Boolean visited
+) {}

--- a/src/main/java/com/earseo/route/dto/response/RouteItemResponse.java
+++ b/src/main/java/com/earseo/route/dto/response/RouteItemResponse.java
@@ -31,5 +31,8 @@ public record RouteItemResponse(
         String itemMajorTheme,
 
         @Schema(description = "이야기 요약 아이디", example = "1L")
-        Long summaryId
+        Long summaryId,
+
+        @Schema(description = "방문(리스닝) 완료 여부", example = "false")
+        Boolean visited
 ) {}

--- a/src/main/java/com/earseo/route/dto/response/SuccessResponse.java
+++ b/src/main/java/com/earseo/route/dto/response/SuccessResponse.java
@@ -1,0 +1,13 @@
+package com.earseo.route.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "성공 여부 응답")
+public record SuccessResponse(
+        @Schema(description = "성공 여부", example = "true")
+        boolean isSuccess
+) {
+    public static SuccessResponse ok() {
+        return new SuccessResponse(true);
+    }
+}

--- a/src/main/java/com/earseo/route/entity/Route.java
+++ b/src/main/java/com/earseo/route/entity/Route.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.LineString;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -31,6 +32,9 @@ public class Route {
 
     @Column(name = "started_at", nullable = false)
     private LocalDateTime startedAt;
+
+    @Column(name = "path", nullable = false, columnDefinition = "geometry(LineString, 4326)")
+    private LineString path;
 
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
@@ -65,6 +69,19 @@ public class Route {
 
     public void complete() {
         this.status = RouteStatus.COMPLETED;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+        if (this.startedAt == null) this.startedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/earseo/route/entity/RouteItem.java
+++ b/src/main/java/com/earseo/route/entity/RouteItem.java
@@ -88,8 +88,8 @@ public class RouteItem {
         return item;
     }
 
-    public void markVisited() {
-        this.visited = true;
+    public void markVisited(boolean visited) {
+        this.visited = visited;
     }
 
     @PrePersist

--- a/src/main/java/com/earseo/route/entity/RouteItem.java
+++ b/src/main/java/com/earseo/route/entity/RouteItem.java
@@ -49,11 +49,17 @@ public class RouteItem {
     @Column(name = "longitude")
     private Double longitude;
 
+    @Column(name = "summary_id")
+    private Long summaryId;
+
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    @Column(name = "visited", nullable = false)
+    private boolean visited;
 
     public static RouteItem of(
             RouteRefType refType,
@@ -64,7 +70,8 @@ public class RouteItem {
             Double latitude,
             Double longitude,
             String docentUrl,
-            String theme
+            String theme,
+            Long summaryId
     ) {
         RouteItem item = new RouteItem();
         item.refType = refType;
@@ -76,7 +83,13 @@ public class RouteItem {
         item.longitude = longitude;
         item.docentUrl = docentUrl;
         item.theme = theme;
+        item.summaryId = summaryId;
+        item.visited = false;
         return item;
+    }
+
+    public void markVisited() {
+        this.visited = true;
     }
 
     @PrePersist

--- a/src/main/java/com/earseo/route/repository/RouteItemRepository.java
+++ b/src/main/java/com/earseo/route/repository/RouteItemRepository.java
@@ -1,10 +1,26 @@
 package com.earseo.route.repository;
 
 import com.earseo.route.entity.RouteItem;
+import com.earseo.route.entity.RouteStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RouteItemRepository extends JpaRepository<RouteItem, Long> {
-    List<RouteItem> findByRouteIdOrderByIdAsc(Long routeId);
+    @Query("""
+        select ri
+        from RouteItem ri
+        join fetch ri.route r
+        where ri.id = :routeItemId
+          and r.memberId = :memberId
+          and r.status = :status
+    """)
+    Optional<RouteItem> findWithRouteByIdAndMemberIdAndRouteStatus(
+            @Param("routeItemId") Long routeItemId,
+            @Param("memberId") Long memberId,
+            @Param("status") RouteStatus status
+    );
 }

--- a/src/main/java/com/earseo/route/repository/RouteRepository.java
+++ b/src/main/java/com/earseo/route/repository/RouteRepository.java
@@ -2,10 +2,14 @@ package com.earseo.route.repository;
 
 import com.earseo.route.entity.Route;
 import com.earseo.route.entity.RouteStatus;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface RouteRepository extends JpaRepository<Route, Long> {
     Optional<Route> findByMemberIdAndStatus(Long memberId, RouteStatus status);
+
+    @EntityGraph(attributePaths = "items")
+    Optional<Route> findWithItemsByMemberIdAndStatus(Long memberId, RouteStatus status);
 }

--- a/src/main/java/com/earseo/route/service/RouteInProgressService.java
+++ b/src/main/java/com/earseo/route/service/RouteInProgressService.java
@@ -87,7 +87,7 @@ public class RouteInProgressService {
         Route route = routeRepository.findWithItemsByMemberIdAndStatus(memberId, RouteStatus.IN_PROGRESS).orElse(null);
 
         if (route == null) {
-            return null;
+            return new InProgressRouteDetailResponse(null, List.of(), List.of());
         }
 
         List<RoutePathPointResponse> pathResponses = route.getPath() == null ? List.of() : getPaths(route.getPath()).stream()

--- a/src/main/java/com/earseo/route/service/RouteInProgressService.java
+++ b/src/main/java/com/earseo/route/service/RouteInProgressService.java
@@ -16,9 +16,12 @@ import com.earseo.route.repository.RouteRepository;
 import com.earseo.route.service.route.RoutePathPoint;
 import com.earseo.route.service.route.RouteSearchResult;
 import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LineString;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -119,5 +122,23 @@ public class RouteInProgressService {
         }
 
         return start + " - " + end;
+    }
+
+    /***
+     * route 엔티티 객체의 geom 형식을 front에 전달가능한 형태로 변환하는 메소드
+     *
+     */
+    public List<RoutePathPoint> getPaths(LineString lineString){
+        Coordinate[] coords = lineString.getCoordinates();
+
+        List<RoutePathPoint> result = new ArrayList<>(coords.length);
+
+        for (Coordinate c : coords) {
+            result.add(new RoutePathPoint(
+                    c.getX(),
+                    c.getY()
+            ));
+        }
+        return result;
     }
 }

--- a/src/main/java/com/earseo/route/service/RouteInProgressService.java
+++ b/src/main/java/com/earseo/route/service/RouteInProgressService.java
@@ -11,7 +11,6 @@ import com.earseo.route.dto.response.SightMetaResponse;
 import com.earseo.route.entity.Route;
 import com.earseo.route.entity.RouteItem;
 import com.earseo.route.entity.RouteStatus;
-import com.earseo.route.repository.RouteItemRepository;
 import com.earseo.route.repository.RouteRepository;
 import com.earseo.route.service.route.RoutePathPoint;
 import com.earseo.route.service.route.RouteSearchResult;
@@ -30,10 +29,8 @@ import java.util.List;
 public class RouteInProgressService {
 
     private final SightFeignClient sightFeignClient;
-//    private final RouteSearchService routeSearchService;
     private final RouteSearchService routeSearchService;
     private final RouteRepository routeRepository;
-    private final RouteItemRepository routeItemRepository;
 
     public InProgressRouteDetailResponse createInProgressRoute(Long memberId, CreateRouteRequest request) {
 
@@ -60,7 +57,8 @@ public class RouteInProgressService {
                 item.latitude(),
                 item.longitude(),
                 item.docentUrl(),
-                item.theme()
+                item.theme(),
+                item.summaryId()
         )).toList();
 
         route.addItems(routeItems);
@@ -70,17 +68,9 @@ public class RouteInProgressService {
                 .map(p -> new RoutePathPointResponse(p.longitude(), p.latitude()))
                 .toList();
 
-        List<RouteItemResponse> itemResponses = searchResult.items().stream().map(item -> new RouteItemResponse(
-                item.type(),
-                item.refId(),
-                item.name(),
-                item.imageUrl(),
-                item.address(),
-                new RoutePathPointResponse(item.longitude(), item.latitude()),
-                item.docentUrl(),
-                item.theme(),
-                item.summaryId()
-        )).toList();
+        List<RouteItemResponse> itemResponses = routeItems.stream()
+                .map(this::toRouteItemResponse)
+                .toList();
 
         return new InProgressRouteDetailResponse(
                 savedRoute.getId(),
@@ -89,10 +79,33 @@ public class RouteInProgressService {
         );
     }
 
+    @Transactional(readOnly = true)
+    public InProgressRouteDetailResponse getInProgressRoute(Long memberId) {
+
+        Route route = routeRepository.findWithItemsByMemberIdAndStatus(memberId, RouteStatus.IN_PROGRESS).orElse(null);
+
+        if (route == null) {
+            return null;
+        }
+
+        List<RoutePathPointResponse> pathResponses = route.getPath() == null ? List.of() : getPaths(route.getPath()).stream()
+                .map(p -> new RoutePathPointResponse(p.longitude(), p.latitude()))
+                .toList();
+
+        List<RouteItemResponse> itemResponses = route.getItems().stream()
+                .map(this::toRouteItemResponse)
+                .toList();
+
+        return new InProgressRouteDetailResponse(
+                route.getId(),
+                pathResponses,
+                itemResponses
+        );
+    }
+
     public void completeRoute(Long memberId, Long routeId) {
         Route route = routeRepository.findById(routeId)
-                .orElseThrow(() ->
-                        new BaseException(RouteError.ROUTE_NOT_FOUND));
+                .orElseThrow(() -> new BaseException(RouteError.ROUTE_NOT_FOUND));
 
         if (!route.getMemberId().equals(memberId)) {
             throw new BaseException(RouteError.ROUTE_NOT_OWNER);
@@ -105,10 +118,21 @@ public class RouteInProgressService {
         route.complete();
     }
 
-    private static RoutePathPointResponse toPathResponse(RoutePathPoint p) {
-        return new RoutePathPointResponse(p.longitude(), p.latitude());
+    private RouteItemResponse toRouteItemResponse(RouteItem item) {
+        return new RouteItemResponse(
+                item.getRefType(),
+                item.getRefId(),
+                item.getName(),
+                item.getImageUrl(),
+                item.getAddress(),
+                new RoutePathPointResponse(item.getLongitude(), item.getLatitude()),
+                item.getDocentUrl(),
+                item.getTheme(),
+                item.getSummaryId(),
+                item.isVisited()
+        );
     }
-
+    
     private String buildRouteName(RouteSearchResult searchResult) {
         if (searchResult.items().isEmpty()) {
             return "나의 경로";

--- a/src/main/java/com/earseo/route/service/RouteInProgressService.java
+++ b/src/main/java/com/earseo/route/service/RouteInProgressService.java
@@ -11,6 +11,7 @@ import com.earseo.route.dto.response.SightMetaResponse;
 import com.earseo.route.entity.Route;
 import com.earseo.route.entity.RouteItem;
 import com.earseo.route.entity.RouteStatus;
+import com.earseo.route.repository.RouteItemRepository;
 import com.earseo.route.repository.RouteRepository;
 import com.earseo.route.service.route.RoutePathPoint;
 import com.earseo.route.service.route.RouteSearchResult;
@@ -31,6 +32,7 @@ public class RouteInProgressService {
     private final SightFeignClient sightFeignClient;
     private final RouteSearchService routeSearchService;
     private final RouteRepository routeRepository;
+    private final RouteItemRepository routeItemRepository;
 
     public InProgressRouteDetailResponse createInProgressRoute(Long memberId, CreateRouteRequest request) {
 
@@ -101,6 +103,15 @@ public class RouteInProgressService {
                 pathResponses,
                 itemResponses
         );
+    }
+
+    public void updateRouteItemVisited(Long memberId, Long routeItemId, boolean visited) {
+
+        RouteItem routeItem = routeItemRepository
+                .findWithRouteByIdAndMemberIdAndRouteStatus(routeItemId, memberId, RouteStatus.IN_PROGRESS)
+                .orElseThrow(() -> new BaseException(RouteError.ROUTE_ITEM_NOT_IN_PROGRESS));
+
+        routeItem.markVisited(visited);
     }
 
     public void completeRoute(Long memberId, Long routeId) {

--- a/src/main/java/com/earseo/route/service/RouteSearchService.java
+++ b/src/main/java/com/earseo/route/service/RouteSearchService.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -35,7 +36,7 @@ public class RouteSearchService {
 
     public RouteSearchResult findRoute(Long memberId, List<SightMetaResponse> sights, PointRequest currentPoint) {
 
-        GeometryFactory geometryFactory = new GeometryFactory();
+        GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
 
         List<Coordinate> allCoords = new ArrayList<>();
 
@@ -113,9 +114,10 @@ public class RouteSearchService {
         BaseResponse<GetRouteListSpotResponse> routeListSpotResponse = storyFeignClient.getPathsSpotList(new GetRouteListSpotRequest(paths, StoryConcept.TIP,null));
 
         Coordinate[] coordArray = allCoords.toArray(new Coordinate[0]);
-        LineString  lineString = geometryFactory.createLineString(coordArray);
+        LineString lineString = geometryFactory.createLineString(coordArray);
+        lineString.setSRID(4326);
 
-        return new RouteSearchResult(routes, getItems(sights,routeListSpotResponse.data()));
+        return new RouteSearchResult(routes, getItems(sights,routeListSpotResponse.data()), lineString);
     }
 
     private List<RouteSearchItem> getItems(List<SightMetaResponse> sights, GetRouteListSpotResponse routeListSpotResponse) {

--- a/src/main/java/com/earseo/route/service/route/DummyRouteSearchService.java
+++ b/src/main/java/com/earseo/route/service/route/DummyRouteSearchService.java
@@ -5,18 +5,22 @@ import org.springframework.stereotype.Service;
 
 import java.util.Collections;
 import java.util.List;
+import org.locationtech.jts.geom.LineString;
+
+/** 테스트용! 기능 개발 완료 후 제거 예정
+ * - 테스트 통과 & 컴파일용 스텁(Stub)
+ * - API 플로우 검증용
+ */
 
 @Service
 public class DummyRouteSearchService implements RouteSearchService {
 
     @Override
     public RouteSearchResult findRoute(Long memberId, List<SightMetaResponse> sights) {
-        /** todo: 경로 찾기 로직 구현 예정
-         * 지금은 빈 결과를 반환해서 전체 플로우만 확인
-         **/
         return new RouteSearchResult(
-                Collections.emptyList(),
-                Collections.emptyList()
+                Collections.<RoutePathPoint>emptyList(),
+                Collections.<RouteSearchItem>emptyList(),
+                (LineString) null
         );
     }
 }

--- a/src/main/java/com/earseo/route/service/route/RouteSearchResult.java
+++ b/src/main/java/com/earseo/route/service/route/RouteSearchResult.java
@@ -1,9 +1,12 @@
 package com.earseo.route.service.route;
 
+import org.locationtech.jts.geom.LineString;
+
 import java.util.List;
 
 public record RouteSearchResult(
         List<RoutePathPoint> path,
-        List<RouteSearchItem> items
+        List<RouteSearchItem> items,
+        LineString lineString
 ) {
 }

--- a/src/test/java/com/earseo/route/service/RouteInProgressServiceTest.java
+++ b/src/test/java/com/earseo/route/service/RouteInProgressServiceTest.java
@@ -1,193 +1,367 @@
-//package com.earseo.route.service;
-//
-//import com.earseo.route.common.exception.BaseException;
-//import com.earseo.route.common.exception.RouteError;
-//import com.earseo.route.controller.client.SightFeignClient;
-//import com.earseo.route.dto.request.CreateRouteRequest;
-//import com.earseo.route.dto.response.InProgressRouteDetailResponse;
-//import com.earseo.route.dto.response.SightMetaResponse;
-//import com.earseo.route.entity.Route;
-//import com.earseo.route.entity.RouteRefType;
-//import com.earseo.route.entity.RouteStatus;
-//import com.earseo.route.repository.RouteItemRepository;
-//import com.earseo.route.repository.RouteRepository;
-//import com.earseo.route.service.route.RoutePathPoint;
-//import com.earseo.route.service.route.RouteSearchItem;
-//import com.earseo.route.service.route.RouteSearchResult;
-//import com.earseo.route.service.route.RouteSearchService;
-//import org.assertj.core.api.Assertions;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//
-//import java.util.List;
-//import java.util.Optional;
-//
-//import org.mockito.Mockito;
-//
-//@ExtendWith(MockitoExtension.class)
-//class RouteInProgressServiceTest {
-//
-//    @Mock
-//    private SightFeignClient sightFeignClient;
-//
-//    @Mock
-//    private RouteSearchService routeSearchService;
-//
-//    @Mock
-//    private RouteRepository routeRepository;
-//
-//    @Mock
-//    private RouteItemRepository routeItemRepository;
-//
-//    @InjectMocks
-//    private RouteInProgressService routeInProgressService;
-//
-//    @Test
-//    @DisplayName("placeIds가 비어 있으면 예외 발생")
-//    void createInProgressRoute_빈ID리스트_예외() {
-//        //given
-//        CreateRouteRequest req = new CreateRouteRequest(List.of());
-//
-//        // when
-//        BaseException ex = Assertions.catchThrowableOfType(
-//                () -> routeInProgressService.createInProgressRoute(1L, req),
-//                BaseException.class
-//        );
-//
-//        // then
-//        Assertions.assertThat(ex.getErrorCode().getStatus()).isEqualTo(RouteError.INVALID_PLACE_IDS.getStatus());
-//        Assertions.assertThat(ex.getErrorCode().getMessage()).isEqualTo(RouteError.INVALID_PLACE_IDS.getMessage());
-//    }
-//
-//    @Test
-//    @DisplayName("정상 요청 시 - SIGHT 메타 조회 → RouteSearchService 호출 → 응답 반환")
-//    void createInProgressRoute_성공() {
-//        //given
-//        long memberId = 10L;
-//        List<String> placeIds = List.of("1","4");
-//
-//        CreateRouteRequest req = new CreateRouteRequest(placeIds);
-//
-//        // mock - SightFeignClient
-//        List<SightMetaResponse> mockedSights = List.of(
-//                new SightMetaResponse("1", "경복궁", "서울 종로구", "imageUrl1", 127.12334, 37.12344, "docentUrl1", "A01"),
-//                new SightMetaResponse("13", "DDP", "서울 중구", "imageUrl2", 127.14534, 37.17644, "docentUrl2", "A01")
-//        );
-//        Mockito.when(sightFeignClient.getSightByIds(placeIds)).thenReturn(mockedSights);
-//
-//        // mock - RouteSearchService
-//        RouteSearchResult mockedResult = new RouteSearchResult(
-//                // path
-//                List.of(
-//                        new RoutePathPoint(126.92034, 37.53222),
-//                        new RoutePathPoint(126.24478, 37.23285)
-//                ),
-//
-//                // items
-//                List.of(
-//                        new RouteSearchItem(RouteRefType.SIGHT, "1", "경복궁", "img1", "서울 종로구",
-//                                126.97, 37.57, "docent1", "HISTORY",null),
-//                        new RouteSearchItem(RouteRefType.STORY_SPOT, "4", "DDP", null, null,
-//                                126.98, 37.56, "docent2", null,null)
-//                )
-//        );
-//        Mockito.when(routeSearchService.findRoute(memberId, mockedSights)).thenReturn(mockedResult);
-//
-//        Mockito.when(routeRepository.save(Mockito.any(Route.class))).thenAnswer(invocation -> invocation.getArgument(0));
-//
-//        //when
-//        InProgressRouteDetailResponse response = routeInProgressService.createInProgressRoute(memberId, req);
-//
-//        //then
-//        Assertions.assertThat(response).isNotNull();
-//
-//        // path 검증
-//        Assertions.assertThat(response.path()).hasSize(2);
-//        Assertions.assertThat(response.path().get(0).longitude()).isEqualTo(126.92034);
-//        Assertions.assertThat(response.path().get(0).latitude()).isEqualTo(37.53222);
-//
-//        // items 검증
-//        Assertions.assertThat(response.routeItems()).hasSize(2);
-//        Assertions.assertThat(response.routeItems().get(0).itemId()).isEqualTo("1");
-//        Assertions.assertThat(response.routeItems().get(1).itemId()).isEqualTo("4");
-//
-//        // verify mock
-//        Mockito.verify(sightFeignClient, Mockito.times(1)).getSightByIds(placeIds);
-//        Mockito.verify(routeSearchService, Mockito.times(1)).findRoute(memberId, mockedSights);
-//        Mockito.verify(routeRepository, Mockito.times(1)).save(Mockito.any(Route.class));
-//    }
-//
-//    @Test
-//    @DisplayName("경로 정상 종료 - IN_PROGRESS → COMPLETED")
-//    void completeRoute_성공() {
-//        //given
-//        long memberId = 1L;
-//        long routeId = 100L;
-//
-//        Route route = Mockito.mock(Route.class);
-//        Mockito.when(route.getMemberId()).thenReturn(memberId);
-//        Mockito.when(route.getStatus()).thenReturn(RouteStatus.IN_PROGRESS);
-//
-//        Mockito.when(routeRepository.findById(routeId)).thenReturn(Optional.of(route));
-//
-//        //when
-//        routeInProgressService.completeRoute(memberId, routeId);
-//
-//        //then
-//        Mockito.verify(route, Mockito.times(1)).complete();
-//    }
-//
-//    @Test
-//    @DisplayName("경로 정상 종료 - 소유자가 아니면 예외")
-//    void completeRoute_소유자아님_예외() {
-//        //given
-//        Long memberId = 1L;
-//        Long routeId = 100L;
-//
-//        Route route = Mockito.mock(Route.class);
-//        Mockito.when(route.getMemberId()).thenReturn(999L);
-//
-//        Mockito.when(routeRepository.findById(routeId))
-//                .thenReturn(Optional.of(route));
-//
-//        //when
-//        BaseException ex = Assertions.catchThrowableOfType(
-//                () -> routeInProgressService.completeRoute(memberId, routeId),
-//                BaseException.class
-//        );
-//
-//        //then
-//        Assertions.assertThat(ex.getErrorCode().getStatus()).isEqualTo(RouteError.ROUTE_NOT_OWNER.getStatus());
-//        Mockito.verify(route, Mockito.never()).complete();
-//    }
-//
-//    @Test
-//    @DisplayName("경로 정상 종료 - IN_PROGRESS가 아니면 예외")
-//    void completeRoute_진행중아님_예외() {
-//        // given
-//        Long memberId = 1L;
-//        Long routeId = 100L;
-//
-//        Route route = Mockito.mock(Route.class);
-//        Mockito.when(route.getMemberId()).thenReturn(memberId);
-//        Mockito.when(route.getStatus()).thenReturn(RouteStatus.COMPLETED);
-//
-//        Mockito.when(routeRepository.findById(routeId))
-//                .thenReturn(Optional.of(route));
-//
-//        // when
-//        BaseException ex = Assertions.catchThrowableOfType(
-//                () -> routeInProgressService.completeRoute(memberId, routeId),
-//                BaseException.class
-//        );
-//
-//        // then
-//        Assertions.assertThat(ex.getErrorCode().getStatus()).isEqualTo(RouteError.ROUTE_NOT_IN_PROGRESS.getStatus());
-//        Mockito.verify(route, Mockito.never()).complete();
-//    }
-//
-//}
+package com.earseo.route.service;
+
+import com.earseo.route.common.exception.BaseException;
+import com.earseo.route.common.exception.RouteError;
+import com.earseo.route.controller.client.SightFeignClient;
+import com.earseo.route.dto.request.CreateRouteRequest;
+import com.earseo.route.dto.response.InProgressRouteDetailResponse;
+import com.earseo.route.dto.response.RouteItemResponse;
+import com.earseo.route.dto.response.SightMetaResponse;
+import com.earseo.route.entity.Route;
+import com.earseo.route.entity.RouteItem;
+import com.earseo.route.entity.RouteRefType;
+import com.earseo.route.entity.RouteStatus;
+import com.earseo.route.repository.RouteItemRepository;
+import com.earseo.route.repository.RouteRepository;
+import com.earseo.route.service.route.RoutePathPoint;
+import com.earseo.route.service.route.RouteSearchItem;
+import com.earseo.route.service.route.RouteSearchResult;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+class RouteInProgressServiceTest {
+
+    @Mock
+    private SightFeignClient sightFeignClient;
+
+    @Mock
+    private RouteSearchService routeSearchService;
+
+    @Mock
+    private RouteRepository routeRepository;
+
+    @Mock
+    private RouteItemRepository routeItemRepository;
+
+    @InjectMocks
+    private RouteInProgressService routeInProgressService;
+
+    @Test
+    @DisplayName("createInProgressRoute: placeIds 비어있으면 INVALID_PLACE_IDS")
+    void createInProgressRoute_빈ID리스트_예외() {
+        // given
+        CreateRouteRequest req = new CreateRouteRequest(List.of(), null);
+
+        // when
+        BaseException ex = Assertions.catchThrowableOfType(
+                () -> routeInProgressService.createInProgressRoute(1L, req),
+                BaseException.class
+        );
+
+        // then
+        Assertions.assertThat(ex.getErrorCode().getStatus())
+                .isEqualTo(RouteError.INVALID_PLACE_IDS.getStatus());
+    }
+
+    @Test
+    @DisplayName("createInProgressRoute: 정상 - 기존 IN_PROGRESS 삭제 → sight 메타 조회 → findRoute → 저장 → 응답 매핑")
+    void createInProgressRoute_성공() {
+        //given
+        long memberId = 10L;
+        List<String> placeIds = List.of("1","4");
+        CreateRouteRequest req = new CreateRouteRequest(placeIds, null);
+
+        Route existing = Mockito.mock(Route.class);
+        Mockito.when(routeRepository.findByMemberIdAndStatus(memberId, RouteStatus.IN_PROGRESS))
+                .thenReturn(Optional.of(existing));
+
+        List<SightMetaResponse> mockedSights = List.of(
+                new SightMetaResponse(
+                        "1",
+                        "경복궁",
+                        "서울 종로구",
+                        "image1",
+                        37.57,
+                        126.97,
+                        "docent1",
+                        "A01"),
+                new SightMetaResponse(
+                        "4",
+                        "DDP",
+                        "서울 중구",
+                        "image2",
+                        37.56,
+                        127.00,
+                        "docent2",
+                        "A02")
+        );
+        Mockito.when(sightFeignClient.getSightByIds(placeIds)).thenReturn(mockedSights);
+
+        GeometryFactory gf = new GeometryFactory();
+        LineString lineString = gf.createLineString(new Coordinate[]{
+                new Coordinate(126.97, 37.57),
+                new Coordinate(127.00, 37.56)
+        });
+
+        RouteSearchResult mockedResult = new RouteSearchResult(
+                List.of(
+                        new RoutePathPoint(126.97, 37.57),
+                        new RoutePathPoint(127.00, 37.56)
+                ),
+                List.of(
+                        new RouteSearchItem(
+                                RouteRefType.SIGHT,
+                                "1",
+                                "경복궁",
+                                "img1",
+                                "서울 종로구",
+                                37.57,
+                                126.97,
+                                "docent1",
+                                "A01",
+                                null),
+                        new RouteSearchItem(
+                                RouteRefType.STORY_SPOT,
+                                "999",
+                                "스토리 스팟",
+                                null,
+                                null,
+                                37.565,
+                                126.985,
+                                null,
+                                null,
+                                123L)
+                ),
+                lineString
+        );
+
+        Mockito.when(routeSearchService.findRoute(memberId, mockedSights, req.point()))
+                .thenReturn(mockedResult);
+
+        Route savedRoute = Mockito.mock(Route.class);
+        Mockito.when(savedRoute.getId()).thenReturn(1L);
+        Mockito.when(routeRepository.save(Mockito.any(Route.class))).thenReturn(savedRoute);
+
+        // when
+        InProgressRouteDetailResponse res = routeInProgressService.createInProgressRoute(memberId, req);
+
+        // then
+        Assertions.assertThat(res).isNotNull();
+        Assertions.assertThat(res.routeId()).isEqualTo(1L);
+
+        Assertions.assertThat(res.path()).hasSize(2);
+        Assertions.assertThat(res.routeItems()).hasSize(2);
+
+        RouteItemResponse second = res.routeItems().get(1);
+        Assertions.assertThat(second.itemType()).isEqualTo(RouteRefType.STORY_SPOT);
+        Assertions.assertThat(second.summaryId()).isEqualTo(123L);
+        Assertions.assertThat(second.visited()).isFalse();
+
+        // verify
+        Mockito.verify(routeRepository, Mockito.times(1))
+                .findByMemberIdAndStatus(memberId, RouteStatus.IN_PROGRESS);
+        Mockito.verify(routeRepository, Mockito.times(1))
+                .delete(existing);
+        Mockito.verify(sightFeignClient, Mockito.times(1))
+                .getSightByIds(placeIds);
+        Mockito.verify(routeSearchService, Mockito.times(1))
+                .findRoute(memberId, mockedSights, req.point());
+        Mockito.verify(routeRepository, Mockito.times(1))
+                .save(Mockito.any(Route.class));
+    }
+
+    @Test
+    @DisplayName("getInProgressRoute: 진행 중 경로 없으면 null 반환")
+    void getInProgressRoute_없음_null() {
+        // given
+        long memberId = 10L;
+
+        Mockito.when(routeRepository.findWithItemsByMemberIdAndStatus(memberId, RouteStatus.IN_PROGRESS))
+                .thenReturn(Optional.empty());
+
+        // when
+        InProgressRouteDetailResponse res = routeInProgressService.getInProgressRoute(memberId);
+
+        // then
+        Assertions.assertThat(res).isNull();
+        Mockito.verify(routeRepository, Mockito.times(1))
+                .findWithItemsByMemberIdAndStatus(memberId, RouteStatus.IN_PROGRESS);
+    }
+
+    @Test
+    @DisplayName("getInProgressRoute: path가 null이면 path=[] 반환")
+    void getInProgressRoute_pathNull_빈리스트() {
+        // given
+        long memberId = 10L;
+
+        Route route = Mockito.mock(Route.class);
+        Mockito.when(route.getId()).thenReturn(777L);
+        Mockito.when(route.getPath()).thenReturn(null);
+
+        RouteItem item1 = Mockito.mock(RouteItem.class);
+        Mockito.when(item1.getRefType()).thenReturn(RouteRefType.SIGHT);
+        Mockito.when(item1.getRefId()).thenReturn("1");
+        Mockito.when(item1.getName()).thenReturn("경복궁");
+        Mockito.when(item1.getImageUrl()).thenReturn("img");
+        Mockito.when(item1.getAddress()).thenReturn("addr");
+        Mockito.when(item1.getLongitude()).thenReturn(126.97);
+        Mockito.when(item1.getLatitude()).thenReturn(37.57);
+        Mockito.when(item1.getDocentUrl()).thenReturn("docent");
+        Mockito.when(item1.getTheme()).thenReturn("A01");
+        Mockito.when(item1.getSummaryId()).thenReturn(null);
+        Mockito.when(item1.isVisited()).thenReturn(false);
+
+        Mockito.when(route.getItems()).thenReturn(List.of(item1));
+
+        Mockito.when(routeRepository.findWithItemsByMemberIdAndStatus(memberId, RouteStatus.IN_PROGRESS))
+                .thenReturn(Optional.of(route));
+
+        // when
+        InProgressRouteDetailResponse res = routeInProgressService.getInProgressRoute(memberId);
+
+        // then
+        Assertions.assertThat(res).isNotNull();
+        Assertions.assertThat(res.routeId()).isEqualTo(777L);
+        Assertions.assertThat(res.path()).isEmpty();
+        Assertions.assertThat(res.routeItems()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("getInProgressRoute: 진행 중 경로 있으면 path(LineString) + items(visited 포함) 반환")
+    void getInProgressRoute_성공() {
+        // given
+        long memberId = 10L;
+
+        Route route = Mockito.mock(Route.class);
+
+        GeometryFactory gf = new GeometryFactory();
+        LineString lineString = gf.createLineString(new Coordinate[]{
+                new Coordinate(126.97, 37.57),
+                new Coordinate(127.00, 37.56)
+        });
+
+        Mockito.when(route.getId()).thenReturn(777L);
+        Mockito.when(route.getPath()).thenReturn(lineString);
+
+        RouteItem item1 = Mockito.mock(RouteItem.class);
+        Mockito.when(item1.getRefType()).thenReturn(RouteRefType.SIGHT);
+        Mockito.when(item1.getRefId()).thenReturn("1");
+        Mockito.when(item1.getName()).thenReturn("경복궁");
+        Mockito.when(item1.getImageUrl()).thenReturn("img");
+        Mockito.when(item1.getAddress()).thenReturn("addr");
+        Mockito.when(item1.getLongitude()).thenReturn(126.97);
+        Mockito.when(item1.getLatitude()).thenReturn(37.57);
+        Mockito.when(item1.getDocentUrl()).thenReturn("docent");
+        Mockito.when(item1.getTheme()).thenReturn("A01");
+        Mockito.when(item1.getSummaryId()).thenReturn(null);
+        Mockito.when(item1.isVisited()).thenReturn(true);
+
+        Mockito.when(route.getItems()).thenReturn(List.of(item1));
+
+        Mockito.when(routeRepository.findWithItemsByMemberIdAndStatus(memberId, RouteStatus.IN_PROGRESS))
+                .thenReturn(Optional.of(route));
+
+        // when
+        InProgressRouteDetailResponse res = routeInProgressService.getInProgressRoute(memberId);
+
+        // then
+        Assertions.assertThat(res).isNotNull();
+        Assertions.assertThat(res.routeId()).isEqualTo(777L);
+
+        Assertions.assertThat(res.path()).hasSize(2);
+        Assertions.assertThat(res.path().getFirst().longitude()).isEqualTo(126.97);
+        Assertions.assertThat(res.path().getFirst().latitude()).isEqualTo(37.57);
+
+        Assertions.assertThat(res.routeItems()).hasSize(1);
+        Assertions.assertThat(res.routeItems().getFirst().visited()).isTrue();
+    }
+
+    @Test
+    @DisplayName("completeRoute: 경로 없음 -> ROUTE_NOT_FOUND")
+    void completeRoute_경로없음_예외() {
+        // given
+        long memberId = 1L;
+        long routeId = 100L;
+
+        Mockito.when(routeRepository.findById(routeId)).thenReturn(Optional.empty());
+
+        // when
+        BaseException ex = Assertions.catchThrowableOfType(
+                () -> routeInProgressService.completeRoute(memberId, routeId),
+                BaseException.class
+        );
+
+        // then
+        Assertions.assertThat(ex.getErrorCode().getStatus())
+                .isEqualTo(RouteError.ROUTE_NOT_FOUND.getStatus());
+    }
+
+    @Test
+    @DisplayName("completeRoute: 소유자 불일치 -> ROUTE_NOT_OWNER")
+    void completeRoute_소유자아님_예외() {
+        // given
+        long memberId = 1L;
+        long routeId = 100L;
+
+        Route route = Mockito.mock(Route.class);
+        Mockito.when(route.getMemberId()).thenReturn(999L);
+        Mockito.when(routeRepository.findById(routeId)).thenReturn(Optional.of(route));
+
+        // when
+        BaseException ex = Assertions.catchThrowableOfType(
+                () -> routeInProgressService.completeRoute(memberId, routeId),
+                BaseException.class
+        );
+
+        // then
+        Assertions.assertThat(ex.getErrorCode().getStatus())
+                .isEqualTo(RouteError.ROUTE_NOT_OWNER.getStatus());
+        Mockito.verify(route, Mockito.never()).complete();
+    }
+
+    @Test
+    @DisplayName("completeRoute: IN_PROGRESS 아님 -> ROUTE_NOT_IN_PROGRESS")
+    void completeRoute_진행중아님_예외() {
+        // given
+        long memberId = 1L;
+        long routeId = 100L;
+
+        Route route = Mockito.mock(Route.class);
+        Mockito.when(route.getMemberId()).thenReturn(memberId);
+        Mockito.when(route.getStatus()).thenReturn(RouteStatus.COMPLETED);
+        Mockito.when(routeRepository.findById(routeId)).thenReturn(Optional.of(route));
+
+        // when
+        BaseException ex = Assertions.catchThrowableOfType(
+                () -> routeInProgressService.completeRoute(memberId, routeId),
+                BaseException.class
+        );
+
+        // then
+        Assertions.assertThat(ex.getErrorCode().getStatus())
+                .isEqualTo(RouteError.ROUTE_NOT_IN_PROGRESS.getStatus());
+        Mockito.verify(route, Mockito.never()).complete();
+    }
+
+    @Test
+    @DisplayName("completeRoute: 정상 - complete() 호출")
+    void completeRoute_성공() {
+        // given
+        long memberId = 1L;
+        long routeId = 100L;
+
+        Route route = Mockito.mock(Route.class);
+        Mockito.when(route.getMemberId()).thenReturn(memberId);
+        Mockito.when(route.getStatus()).thenReturn(RouteStatus.IN_PROGRESS);
+        Mockito.when(routeRepository.findById(routeId)).thenReturn(Optional.of(route));
+
+        // when
+        routeInProgressService.completeRoute(memberId, routeId);
+
+        // then
+        Mockito.verify(route, Mockito.times(1)).complete();
+    }
+}

--- a/src/test/java/com/earseo/route/service/RouteInProgressServiceTest.java
+++ b/src/test/java/com/earseo/route/service/RouteInProgressServiceTest.java
@@ -174,8 +174,8 @@ class RouteInProgressServiceTest {
     }
 
     @Test
-    @DisplayName("getInProgressRoute: 진행 중 경로 없으면 null 반환")
-    void getInProgressRoute_없음_null() {
+    @DisplayName("getInProgressRoute: 진행 중 경로 없으면 routeId=null, path=[], routeItems=[] 반환")
+    void getInProgressRoute_없음_빈응답() {
         // given
         long memberId = 10L;
 
@@ -186,9 +186,10 @@ class RouteInProgressServiceTest {
         InProgressRouteDetailResponse res = routeInProgressService.getInProgressRoute(memberId);
 
         // then
-        Assertions.assertThat(res).isNull();
-        Mockito.verify(routeRepository, Mockito.times(1))
-                .findWithItemsByMemberIdAndStatus(memberId, RouteStatus.IN_PROGRESS);
+        Assertions.assertThat(res).isNotNull();
+        Assertions.assertThat(res.routeId()).isNull();
+        Assertions.assertThat(res.path()).isEmpty();
+        Assertions.assertThat(res.routeItems()).isEmpty();
     }
 
     @Test

--- a/src/test/java/com/earseo/route/service/RouteInProgressServiceTest.java
+++ b/src/test/java/com/earseo/route/service/RouteInProgressServiceTest.java
@@ -279,6 +279,49 @@ class RouteInProgressServiceTest {
         Assertions.assertThat(res.routeItems().getFirst().visited()).isTrue();
     }
 
+
+    @Test
+    @DisplayName("updateRouteItemVisited: 성공 - IN_PROGRESS이면 markVisited 호출")
+    void updateRouteItemVisited_성공() {
+        // given
+        long memberId = 10L;
+        long routeItemId = 55L;
+
+        RouteItem routeItem = Mockito.mock(RouteItem.class);
+
+        Mockito.when(routeItemRepository.findWithRouteByIdAndMemberIdAndRouteStatus(
+                        routeItemId, memberId, RouteStatus.IN_PROGRESS))
+                .thenReturn(Optional.of(routeItem));
+
+        // when
+        routeInProgressService.updateRouteItemVisited(memberId, routeItemId, true);
+
+        // then
+        Mockito.verify(routeItem, Mockito.times(1)).markVisited(true);
+    }
+
+    @Test
+    @DisplayName("updateRouteItemVisited: 실패 - 조건 불일치(없음/소유자아님/진행중아님) -> ROUTE_ITEM_NOT_IN_PROGRESS")
+    void updateRouteItemVisited_실패() {
+        // given
+        long memberId = 10L;
+        long routeItemId = 55L;
+
+        Mockito.when(routeItemRepository.findWithRouteByIdAndMemberIdAndRouteStatus(
+                        routeItemId, memberId, RouteStatus.IN_PROGRESS))
+                .thenReturn(Optional.empty());
+
+        // when
+        BaseException ex = Assertions.catchThrowableOfType(
+                () -> routeInProgressService.updateRouteItemVisited(memberId, routeItemId, true),
+                BaseException.class
+        );
+
+        // then
+        Assertions.assertThat(ex.getErrorCode().getStatus())
+                .isEqualTo(RouteError.ROUTE_ITEM_NOT_IN_PROGRESS.getStatus());
+    }
+
     @Test
     @DisplayName("completeRoute: 경로 없음 -> ROUTE_NOT_FOUND")
     void completeRoute_경로없음_예외() {


### PR DESCRIPTION
## 🧩 구현/변경 사항
- Route / RouteItem 엔티티 확장
  - Route.path(LineString/geometry) 저장 전제 반영
  - RouteItem.visited(방문/리스닝 여부) 추가
  - RouteItem.summaryId 저장 지원
  - 진행 중 경로 복구/방문 상태 저장을 위한 도메인 기반 필드 구조 정리

- 진행 중 경로 존재 여부 조회 API 
  - 사용자 기준 IN_PROGRESS 경로 존재 여부 조회 서비스/컨트롤러 추가
  - Route.path(LineString)을 위·경도 포인트 리스트로 변환하여 응답
  - RouteItem 목록을 visited 포함 상세 응답으로 매핑
  - 관련 단위 테스트 추가

- RouteItem 방문(visited) 상태 업데이트 API + RouteError 매핑 적용
  - 진행 중 경로의 RouteItem을 대상으로 visited 상태 PATCH 업데이트 API 구현
  - 진행 중 경로/소유자 조건에 맞게 조회 후 visited 반영
  - 관련 단위 테스트 추가
  - 서비스 로직에서 예외를 RouteError 기반으로 매핑 적용

## 사용자 시나리오(UML)
- 진행 중 경로 존재 여부 조회 플로우
```mermaid
sequenceDiagram
    participant C as Client
    participant G as Gateway
    participant R as RouteService

    C->>G: GET /api/user/route/in-progress
    G->>R: 요청 + X-USER-ID
    R->>R: IN_PROGRESS 경로 조회
    alt 진행 중 경로 없음
        R-->>C: null
    else 진행 중 경로 있음
        R->>R: path(LineString) → 좌표 리스트 변환
        R->>R: RouteItem → visited 포함 응답 매핑
        R-->>C: InProgressRouteDetailResponse
    end
```
- 도슨트 리스닝/방문 상태 저장 플로우
```mermaid
sequenceDiagram
    participant C as Client
    participant G as Gateway
    participant R as RouteService

    C->>G: PATCH /api/user/route/items/{routeItemId}/visited
    G->>R: 요청 + X-USER-ID
    R->>R: RouteItem + Route(IN_PROGRESS) 조회
    R->>R: visited 상태 업데이트
    R-->>C: 성공 응답
```

---

## 🧪 테스트 결과
- RouteInProgressServiceTest
  - RouteInProgressService 단위 테스트 전부 통과했으며,
진행 중 경로 조회/종료 및 RouteItem 방문 상태 업데이트와 주요 예외 케이스를 검증했습니다.
  <img width="647" height="246" alt="스크린샷 2026-01-06 오후 11 58 03" src="https://github.com/user-attachments/assets/aa958b36-77b3-404b-ba7a-c443e1412fd9" />


---

## BREAKING CHANGE (옵션)
- 없음

---

## 참고
- route/RouteSearchService와 DummyRouteSearchService는 test 검증용 임시 구현체입니다.

---

## 🪞 회고 및 개선 아이디어 (옵션)
- 없음

---

## 💬 리뷰 받고 싶은 부분 (옵션)
- 없음
